### PR TITLE
Add ejson_body

### DIFF
--- a/src/dreyfus_fabric_search.erl
+++ b/src/dreyfus_fabric_search.erl
@@ -31,7 +31,7 @@
 }).
 
 go(DbName, GroupId, IndexName, QueryArgs) when is_binary(GroupId) ->
-    {ok, DDoc} = fabric:open_doc(DbName, <<"_design/", GroupId/binary>>, []),
+    {ok, DDoc} = fabric:open_doc(DbName, <<"_design/", GroupId/binary>>, [ejson_body]),
     go(DbName, DDoc, IndexName, QueryArgs);
 
 go(DbName, DDoc, IndexName, #index_query_args{bookmark=nil}=QueryArgs) ->


### PR DESCRIPTION
When loading design docs with the ID, we want to add ejson_body
to the list of options so the body is converted to term from binary.
This makes dreyfus compatible with COUCHDB2.0
