### PR TITLE
Add new metric to track the "search request" latency.

### DIFF
--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -11,6 +11,10 @@
 %% the License.
 
 
+{[dreyfus, httpd, search], [
+    {type, histogram},
+    {desc, <<"Distribution of overall search request latency as experienced by the end user">>}
+]}.
 {[dreyfus, rpc, search], [
     {type, histogram},
     {desc, <<"length of a search RPC worker">>}


### PR DESCRIPTION
This metric is different from what we track in clouseau. This basically will track
the overall time it took for the search request, where as the one in Clouseau will
only track the search latency at the shard level.

This will come in handy for tracking the search latency issues as seen  by the end users
and also allow us to add pager triggers based on this.
