### PR TITLE
Don't crash on invalid ddoc

### DIFF
--- a/src/dreyfus_index.erl
+++ b/src/dreyfus_index.erl
@@ -235,20 +235,29 @@ open_index(DbName, #index{analyzer=Analyzer, sig=Sig}) ->
 design_doc_to_index(#doc{id=Id,body={Fields}}, IndexName) ->
     Language = couch_util:get_value(<<"language">>, Fields, <<"javascript">>),
     {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
+    InvalidDDocError = {invalid_design_doc,
+        <<"index `", IndexName/binary, "` must have parameter `index`">>},
     case lists:keyfind(IndexName, 1, RawIndexes) of
         false ->
             {error, {not_found, <<IndexName/binary, " not found.">>}};
         {IndexName, {Index}} ->
             Analyzer = couch_util:get_value(<<"analyzer">>, Index, <<"standard">>),
-            Def = couch_util:get_value(<<"index">>, Index),
-            Sig = ?l2b(couch_util:to_hex(couch_crypto:hash(md5, term_to_binary({Analyzer, Def})))),
-            {ok, #index{
-               analyzer=Analyzer,
-               ddoc_id=Id,
-               def=Def,
-               def_lang=Language,
-               name=IndexName,
-               sig=Sig}}
+            case couch_util:get_value(<<"index">>, Index) of
+                undefined ->
+                    {error, InvalidDDocError};
+                Def ->
+                    Sig = ?l2b(couch_util:to_hex(couch_crypto:hash(md5,
+                        term_to_binary({Analyzer, Def})))),
+                    {ok, #index{
+                        analyzer=Analyzer,
+                        ddoc_id=Id,
+                        def=Def,
+                        def_lang=Language,
+                        name=IndexName,
+                        sig=Sig}}
+            end;
+        _ ->
+            {error, InvalidDDocError}
     end.
 
 reply_with_index(IndexPid, Index, WaitList) ->


### PR DESCRIPTION
This addresses an issue with invalid design doc crashing index updater with `case_clause` when queried index set to either not an object or object with a missing parameter "index"

BugzID: 69570
