### PR TITLE
Improve Search Logging

### DIFF
--- a/src/dreyfus_fabric.erl
+++ b/src/dreyfus_fabric.erl
@@ -54,7 +54,11 @@ handle_error_message({error, Reason}, Worker,
     handle_error(Reason, Worker, Counters);
 handle_error_message({'EXIT', Reason}, Worker,
                      Counters, _Replacements, _StartFun, _StartArgs) ->
-    handle_error({exit, Reason}, Worker, Counters).
+    handle_error({exit, Reason}, Worker, Counters);
+handle_error_message(Reason, Worker, Counters,
+                     _Replacements, _StartFun, _StartArgs) ->
+    couch_log:error("Unexpected error during request: ~p", [Reason]),
+    handle_error(Reason, Worker, Counters).
 
 handle_error(Reason, Worker, Counters0) ->
     Counters = fabric_dict:erase(Worker, Counters0),


### PR DESCRIPTION
Rexi receives an error message that does not match any of the tuples
for the first argument of dreyfus_fabric:handle_error_message/6. This
leads to a function_clause error that bubbles up to chttpd which gets
logged because there is a stack trace involved. By adding an extra
clause that matches all error messages, we attempt to see if progress
can be made by calling handle_error. If progress can succeed, then
nothing gets logged. If the progress cannot succeed, an error will be
sent back to the user again via chttpd:send_error/2. However, if no
stack trace is involved in the error, we won't log the message. Adding
an extra couch_log:error here assures we have something in the logs to
make note of the error message to help us debug.
