### PR TITLE
Add new end point to get disk size information for search index

### DIFF
--- a/src/clouseau_rpc.erl
+++ b/src/clouseau_rpc.erl
@@ -21,10 +21,13 @@
 -export([await/2, commit/2, get_update_seq/1, info/1, search/6, search/2]).
 -export([group1/7, group2/8, group2/2]).
 -export([delete/2, update/3, cleanup/1, cleanup/2]).
--export([analyze/2, version/0]).
+-export([analyze/2, version/0, disk_size/1]).
 
 open_index(Peer, Path, Analyzer) ->
     rpc({main, clouseau()}, {open, Peer, Path, Analyzer}).
+
+disk_size(Path) ->
+    rpc({main, clouseau()}, {disk_size, Path}).
 
 await(Ref, MinSeq) ->
     rpc(Ref, {await, MinSeq}).

--- a/src/dreyfus_fabric_info.erl
+++ b/src/dreyfus_fabric_info.erl
@@ -19,15 +19,15 @@
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--export([go/3]).
+-export([go/4]).
 
-go(DbName, DDocId, IndexName) when is_binary(DDocId) ->
+go(DbName, DDocId, IndexName, InfoLevel) when is_binary(DDocId) ->
     {ok, DDoc} = fabric:open_doc(DbName, <<"_design/", DDocId/binary>>, []),
-    go(DbName, DDoc, IndexName);
+    go(DbName, DDoc, IndexName, InfoLevel);
 
-go(DbName, DDoc, IndexName) ->
+go(DbName, DDoc, IndexName, InfoLevel) ->
     Shards = mem3:shards(DbName),
-    Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, info, [DDoc, IndexName]),
+    Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, InfoLevel, [DDoc, IndexName]),
     RexiMon = fabric_util:create_monitors(Shards),
     Acc0 = {fabric_dict:init(Workers, nil), []},
     try

--- a/src/dreyfus_httpd_handlers.erl
+++ b/src/dreyfus_httpd_handlers.erl
@@ -25,4 +25,5 @@ db_handler(_) -> no_match.
 
 design_handler(<<"_search">>)      -> fun dreyfus_httpd:handle_search_req/3;
 design_handler(<<"_search_info">>) -> fun dreyfus_httpd:handle_info_req/3;
+design_handler(<<"_search_disk_size">>) -> fun dreyfus_httpd:handle_disk_size_req/3;
 design_handler(_) -> no_match.

--- a/src/dreyfus_index_manager.erl
+++ b/src/dreyfus_index_manager.erl
@@ -23,7 +23,7 @@
 -define(BY_PID, dreyfus_by_pid).
 
 % public api.
--export([start_link/0, get_index/2]).
+-export([start_link/0, get_index/2, get_disk_size/2]).
 
 % gen_server api.
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
@@ -37,6 +37,9 @@ start_link() ->
 
 get_index(DbName, Index) ->
     gen_server:call(?MODULE, {get_index, DbName, Index}, infinity).
+
+get_disk_size(DbName, Index) ->
+    gen_server:call(?MODULE, {get_disk_size, DbName, Index}, infinity).
 
 % gen_server functions.
 
@@ -60,6 +63,11 @@ handle_call({get_index, DbName, #index{sig=Sig}=Index}, From, State) ->
     [{_, ExistingPid}] ->
         {reply, {ok, ExistingPid}, State}
     end;
+
+handle_call({get_disk_size, DbName, #index{sig=Sig}=Index}, From, State) ->
+    Path = <<DbName/binary,"/",Sig/binary>>,
+    Reply = clouseau_rpc:disk_size(Path),
+    {reply, Reply, State};
 
 handle_call({open_ok, DbName, Sig, NewPid}, {OpenerPid, _}, State) ->
     link(NewPid),

--- a/src/dreyfus_rpc.erl
+++ b/src/dreyfus_rpc.erl
@@ -19,7 +19,7 @@
 -import(couch_query_servers, [get_os_process/1, ret_os_process/1, proc_prompt/2]).
 
 % public api.
--export([search/4, group1/4, group2/4, info/3]).
+-export([search/4, group1/4, group2/4, info/3, disk_size/3]).
 
 % private callback
 -export([call/5, info_int/3]).
@@ -86,6 +86,17 @@ info_int(DbName, DDoc, IndexName) ->
                 Error ->
                     rexi:reply(Error)
             end;
+        Error ->
+            rexi:reply(Error)
+    end.
+
+disk_size(DbName, DDoc, IndexName) ->
+    erlang:put(io_priority, {interactive, DbName}),
+    check_interactive_mode(),
+    case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
+        {ok, Index} ->
+            Result = dreyfus_index_manager:get_disk_size(DbName, Index),
+            rexi:reply(Result);
         Error ->
             rexi:reply(Error)
     end.


### PR DESCRIPTION
Currently the only way to get the disk size information for the search
index is to use the _search_info end point. But using this point would
lead to opening the search index which is non trivial as lucene has an
overhead for opening the index.

These changes would add a new end point _search_disk_size to get the
disk size information without opening the search index. Sarnie can use
this new end point and avoid opening the search index.

BugzId:87336