### PR TITLE
Improve search blacklist

### DIFF
--- a/src/dreyfus_fabric_group1.erl
+++ b/src/dreyfus_fabric_group1.erl
@@ -36,6 +36,8 @@ go(DbName, GroupId, IndexName, QueryArgs) when is_binary(GroupId) ->
     go(DbName, DDoc, IndexName, QueryArgs);
 
 go(DbName, DDoc, IndexName, #index_query_args{}=QueryArgs) ->
+    DesignName = dreyfus_util:get_design_docid(DDoc),
+    dreyfus_util:maybe_deny_index(DbName, DesignName, IndexName),
     Shards = dreyfus_util:get_shards(DbName, QueryArgs),
     Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, group1, [DDoc,
          IndexName, dreyfus_util:export(QueryArgs)]),

--- a/src/dreyfus_fabric_group2.erl
+++ b/src/dreyfus_fabric_group2.erl
@@ -38,6 +38,8 @@ go(DbName, GroupId, IndexName, QueryArgs) when is_binary(GroupId) ->
     go(DbName, DDoc, IndexName, QueryArgs);
 
 go(DbName, DDoc, IndexName, #index_query_args{}=QueryArgs) ->
+    DesignName = dreyfus_util:get_design_docid(DDoc),
+    dreyfus_util:maybe_deny_index(DbName, DesignName, IndexName),
     Shards = dreyfus_util:get_shards(DbName, QueryArgs),
     Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, group2,
                           [DDoc, IndexName, dreyfus_util:export(QueryArgs)]),

--- a/src/dreyfus_fabric_info.erl
+++ b/src/dreyfus_fabric_info.erl
@@ -27,6 +27,8 @@ go(DbName, DDocId, IndexName, InfoLevel) when is_binary(DDocId) ->
     go(DbName, DDoc, IndexName, InfoLevel);
 
 go(DbName, DDoc, IndexName, InfoLevel) ->
+    DesignName = dreyfus_util:get_design_docid(DDoc),
+    dreyfus_util:maybe_deny_index(DbName, DesignName, IndexName),
     Shards = mem3:shards(DbName),
     Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, InfoLevel, [DDoc, IndexName]),
     RexiMon = fabric_util:create_monitors(Shards),

--- a/src/dreyfus_fabric_search.erl
+++ b/src/dreyfus_fabric_search.erl
@@ -37,6 +37,8 @@ go(DbName, GroupId, IndexName, QueryArgs) when is_binary(GroupId) ->
     go(DbName, DDoc, IndexName, QueryArgs);
 
 go(DbName, DDoc, IndexName, #index_query_args{bookmark=nil}=QueryArgs) ->
+    DesignName = dreyfus_util:get_design_docid(DDoc),
+    dreyfus_util:maybe_deny_index(DbName, DesignName, IndexName),
     Shards = dreyfus_util:get_shards(DbName, QueryArgs),
     Workers = fabric_util:submit_jobs(Shards, dreyfus_rpc, search,
                           [DDoc, IndexName, dreyfus_util:export(QueryArgs)]),

--- a/src/dreyfus_util.erl
+++ b/src/dreyfus_util.erl
@@ -21,6 +21,7 @@
 
 -export([get_shards/2, sort/2, upgrade/1, export/1, time/2]).
 -export([in_black_list/1, in_black_list/3, maybe_deny_index/3]).
+-export([get_design_docid/1]).
 
 get_shards(DbName, #index_query_args{stale=ok}) ->
     mem3:ushards(DbName);
@@ -193,6 +194,9 @@ maybe_deny_index(DbName, GroupId, IndexName) ->
         _ ->
             ok
     end.
+
+get_design_docid(#doc{id = <<"_design/", DesignName/binary>>}) ->
+  DesignName.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
## Overview
Add additional check in dreyfus_fabric_search:go clause, and the same for dreyfus_fabric_info, dreyfus_fabric_group, etc

## Testing recommendations
1. create index based on above design document.
```
 more search_design.json
{
  "_id": "_design/search1",
  "language": "javascript",
  "indexes": {
    "index": {
      "index": "function(doc) { index(\"default\", doc._id) }",
      "options": {
        "collation": "raw"
      }
    },
    "analyzer": "standard"
  }
}
```
2. add it to blacklist
```
localhost:dev jiangph$ ./remsh
Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Eshell V9.2  (abort with ^G)
(node1@127.0.0.1)1>  rpc:multicall(config, set, ["dreyfus_blacklist", "searchdb.search1.index" , "true" ]).
```
3. perform search against blacklisted index
```
localhost:mytest jiangph$ curl -u foo:bar -X GET http://localhost:15984/searchdb/_design/search1/_search/index?q=point*
{"error":"bad_request","reason":"Index <searchdb, search1, index>, is BlackListed"}
localhost:mytest jiangph$ curl -u foo:bar -X GET http://localhost:15984/searchdb/_design/search1/_search_info/index?q=point*
{"error":"bad_request","reason":"Index <searchdb, search1, index>, is BlackListed"}
```

The automatic test case is at
https://github.com/cloudant/testy/pull/469

## Related Issues or Pull Requests
Fogbug bugzid: 109229
https://github.com/cloudant-labs/dreyfus/pull/27

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
