### PR TITLE
use updated_on instead of timestamp_utc in local purge doc

### DIFF
--- a/src/dreyfus_util.erl
+++ b/src/dreyfus_util.erl
@@ -288,7 +288,7 @@ get_local_purge_doc_body(Db, LocalDocId, PurgeSeq, Index) ->
     JsonList = {[
         {<<"_id">>, LocalDocId},
         {<<"purge_seq">>, PurgeSeq},
-        {<<"timestamp_utc">>, NowSecs},
+        {<<"updated_on">>, NowSecs},
         {<<"indexname">>, IdxName},
         {<<"ddoc_id">>, DDocId},
         {<<"signature">>, Sig},

--- a/test/dreyfus_purge_test.erl
+++ b/test/dreyfus_purge_test.erl
@@ -544,7 +544,7 @@ test_local_doc() ->
         {ok, Db} = couch_db:open_int(Shard#shard.name, [?ADMIN_CTX]),
         {ok, LDoc} = couch_db:open_doc(Db, LocalId, []),
         {Props} = couch_doc:to_json_obj(LDoc, []),
-        dreyfus_util:get_value_from_options(<<"timestamp_utc">>, Props),
+        dreyfus_util:get_value_from_options(<<"updated_on">>, Props),
         PurgeSeq = dreyfus_util:get_value_from_options(<<"purge_seq">>, Props),
         Type = dreyfus_util:get_value_from_options(<<"type">>, Props),
         ?assertEqual(<<"dreyfus">>, Type),


### PR DESCRIPTION
Use `updated_on` instead of `timestamp_utc` in local purge doc

COUCHDB-3326