### PR TITLE
Add partition search limit tests

### DIFF
--- a/test/elixir/test/search_partition_test.exs
+++ b/test/elixir/test/search_partition_test.exs
@@ -148,6 +148,19 @@ defmodule SearchPartitionTest do
   end
 
   @tag :with_db
+  test "normal search on non-partitioned dbs without limit", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    create_ddoc(db_name)
+
+    url = "/#{db_name}/_design/library/_search/books"
+    resp = Couch.get(url, query: %{q: "some:field"})
+    assert resp.status_code == 200
+    ids = get_ids(resp)
+    assert ids == ["bar:1", "bar:5", "bar:9", "foo:2", "bar:3", "foo:4", "foo:6", "bar:7", "foo:8", "foo:10"]
+  end
+
+  @tag :with_db
   test "normal search on non-partitioned dbs with limit", context do
     db_name = context[:db_name]
     create_search_docs(db_name)
@@ -158,12 +171,15 @@ defmodule SearchPartitionTest do
     assert resp.status_code == 200
     ids = get_ids(resp)
     assert ids == ["bar:1", "bar:5", "bar:9"]
+  end
 
-    resp = Couch.get(url, query: %{q: "some:field", limit: 200})
-    assert resp.status_code == 200
-    ids = get_ids(resp)
-    assert ids == ["bar:1", "bar:5", "bar:9", "foo:2", "bar:3", "foo:4", "foo:6", "bar:7", "foo:8", "foo:10"]
+  @tag :with_db
+  test "normal search on non-partitioned dbs with over limit", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    create_ddoc(db_name)
 
+    url = "/#{db_name}/_design/library/_search/books"
     resp = Couch.get(url, query: %{q: "some:field", limit: 201})
     assert resp.status_code == 400
   end


### PR DESCRIPTION
## Overview
Add partition search limit tests

## Testing recommendations
mix test --trace ./test/search_partition_test.exs
```
* test Works with bookmarks and limit (1444.5ms)
* test normal search on non-partitioned dbs with limit (1505.1ms)
```

## Related Issues or Pull Requests
https://github.com/cloudant-labs/dreyfus/pull/36

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [] Documentation reflects the changes;