### PR TITLE
Fix function_clause caused by malformed accumulator

### DIFF
--- a/src/dreyfus_index_updater.erl
+++ b/src/dreyfus_index_updater.erl
@@ -83,7 +83,7 @@ load_docs(FDI, {I, IndexPid, Db, Proc, Total, LastCommitTime, ExcludeIdRevs}=Acc
     case timer:now_diff(Now = now(), LastCommitTime) >= 60000000 of
         true ->
             ok = clouseau_rpc:commit(IndexPid, Seq),
-            {ok, {I+1, IndexPid, Db, Proc, Total, Now}};
+            {ok, {I+1, IndexPid, Db, Proc, Total, Now, ExcludeIdRevs}};
         false ->
             {ok, setelement(1, Acc, I+1)}
     end.


### PR DESCRIPTION
In a previous commit we added another item to the accumulator used by
load_docs. Unfortunately one clause was not modified so we send the
original 6-tuple, which then fails to match the function and crashes.

This affects searches of busy indexes, the user gets a function_clause
erorr instead of search results. It does not appear to prevent index
commits, though.

BugzID: 114420