### PR TITLE
Use dedicated search IOQ channel for

### DIFF
--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -51,3 +51,9 @@
     {type, histogram},
     {desc, <<"length of an dreyfus_index info request">>}
 ]}.
+
+%% Declare IOQ2 search channel metrics
+{[couchdb, io_queue2, search, count], [
+    {type, counter},
+    {desc, <<"Search IO directly triggered by client requests">>}
+]}.

--- a/src/dreyfus_index_updater.erl
+++ b/src/dreyfus_index_updater.erl
@@ -28,7 +28,7 @@ update(IndexPid, Index) ->
         ddoc_id = DDocId,
         name = IndexName
     } = Index,
-    erlang:put(io_priority, {view_update, DbName, IndexName}),
+    erlang:put(io_priority, {search, DbName, IndexName}),
     {ok, Db} = couch_db:open_int(DbName, []),
     try
         TotalUpdateChanges = couch_db:count_changes_since(Db, CurSeq),

--- a/src/dreyfus_rpc.erl
+++ b/src/dreyfus_rpc.erl
@@ -38,7 +38,7 @@ group2(DbName, DDoc, IndexName, QueryArgs) ->
 
 call(Fun, DbName, DDoc, IndexName, QueryArgs0) ->
     QueryArgs = dreyfus_util:upgrade(QueryArgs0),
-    erlang:put(io_priority, {interactive, DbName}),
+    erlang:put(io_priority, {search, DbName}),
     check_interactive_mode(),
     {ok, Db} = get_or_create_db(DbName, []),
     #index_query_args{
@@ -75,7 +75,7 @@ info(DbName, DDoc, IndexName) ->
     dreyfus_util:time([rpc, info], MFA).
 
 info_int(DbName, DDoc, IndexName) ->
-    erlang:put(io_priority, {interactive, DbName}),
+    erlang:put(io_priority, {search, DbName}),
     check_interactive_mode(),
     case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
         {ok, Index} ->
@@ -91,7 +91,7 @@ info_int(DbName, DDoc, IndexName) ->
     end.
 
 disk_size(DbName, DDoc, IndexName) ->
-    erlang:put(io_priority, {interactive, DbName}),
+    erlang:put(io_priority, {search, DbName}),
     check_interactive_mode(),
     case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
         {ok, Index} ->


### PR DESCRIPTION
This switches to using a dedicated `search` IOQ channel for all search operations, rather than piggy-backing off of the `interactive` and `view_update` channels. Switching these operations to a dedicated search channel allows us to bypass search from IOQ in isolation, rather than having to bypass both interactive and view update.

We could be more granular and declare a `search` channel and a `search_update` channel, but I'm not sure if that actually matters here.

This PR also adds a metric declaration for search traffic in the `couchdb.io_queue2` metrics namespace. It's somewhat awkward to add that metric here, but if we're not going to introduce the dynamic channels in couchdb-ioq, then we need to declare the metrics somewhere.