### PR TITLE
adjust metric for io_queue-search

### DIFF
--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -52,6 +52,12 @@
     {desc, <<"length of an dreyfus_index info request">>}
 ]}.
 
+%% Declare IOQ search channel metrics
+{[couchdb, io_queue, search], [
+    {type, counter},
+    {desc, <<"Search IO directly triggered by client requests">>}
+]}.
+
 %% Declare IOQ2 search channel metrics
 {[couchdb, io_queue2, search, count], [
     {type, counter},


### PR DESCRIPTION
This PR is to eliminate `unknown metric: [couchdb,io_queue,search]` emission.

