### PR TITLE
Address EPI's startup use of dreyfus_config

### DIFF
--- a/src/dreyfus_config.erl
+++ b/src/dreyfus_config.erl
@@ -3,7 +3,12 @@
  -export([data/0, get/1]).
 
 data() ->
-    config:get("dreyfus_blacklist").
+    try
+        config:get("dreyfus_blacklist")
+    catch error:badarg ->
+        % lazy workaround to address issue with epi invocation on startup
+        []
+    end.
 
 get(Key) ->
     Handle = couch_epi:get_handle({dreyfus, black_list}),


### PR DESCRIPTION
This is a lazy workaround to address a tricky interdependency in the application startup order. Dreyfus depends on the config application, but the plugin engine makes a call to dreyfus_config:data(), which
relies on the config app, before the dreyfus app -- or the config app -- is started. The couch_epi module does not add a dependency on config so if couch_epi happens to start before config the whole VM can crash.

The dreyfus_epi module configures the plugin interface to re-load the configuration data once a second, so ignoring the failure on startup only leaves a window of up to one second where any custom blacklist configuration for the dreyfus app is not loaded.