### PR TITLE
Make dreyfus_index_manager MQ offheap

### DIFF
--- a/src/dreyfus_index_manager.erl
+++ b/src/dreyfus_index_manager.erl
@@ -45,6 +45,7 @@ get_disk_size(DbName, #index{sig=Sig}) ->
 % gen_server functions.
 
 init([]) ->
+    couch_util:set_mqd_off_heap(?MODULE),
     ets:new(?BY_SIG, [set, private, named_table]),
     ets:new(?BY_PID, [set, private, named_table]),
     couch_event:link_listener(?MODULE, handle_db_event, nil, [all_dbs]),


### PR DESCRIPTION
Simple patch to switch drefyus_index_manager's message_queue to be offheap for dealing with large volumes of messages.